### PR TITLE
[EN-1104] Change kafkautils WriteAndCommit param

### DIFF
--- a/kafkautils/consumer.go
+++ b/kafkautils/consumer.go
@@ -51,7 +51,7 @@ func NewConsumer(brokers string, groupID string, overrideOpts ...kafka.ConfigMap
 	return &c, nil
 }
 
-// SubscribeProto subscribes to the provided list of topics. This replaces the current subscription.
+// SubscribeTopics subscribes to the provided list of topics. This replaces the current subscription.
 func (c *Consumer) SubscribeTopics(topics []Topic) error {
 	log.Debug().Strs("topics", TopicsStrings(topics)).Msg("kafka subscribe")
 	return c.Consumer.SubscribeTopics(TopicsStrings(topics), nil)

--- a/kafkautils/producer.go
+++ b/kafkautils/producer.go
@@ -22,7 +22,7 @@ type ProducerInterface interface {
 	AbortTransaction(context.Context) error
 	EnableTransactions() error
 	WriteAndCommitSink(<-chan *Message)
-	WriteAndCommit(string, []byte, proto.Message) error
+	WriteAndCommit(Topic, []byte, proto.Message) error
 	MakeQueueTransactionSink() chan *Message
 	Close()
 }
@@ -32,8 +32,6 @@ type Producer struct {
 	termChan chan bool
 	doneChan chan bool
 	closed   bool
-
-	transactionsInitialized bool
 }
 
 func MustNewProducer(brokers, transactionalID string) *Producer {


### PR DESCRIPTION
`string` was replaced with `Topic` but the interface was forgotten. So several connectors implementing this interface don't compile.
also `transactionsInitialized` was not used.