### PR TITLE
[EN-1104] Update kafka producer mock

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -113,7 +113,7 @@ func (c *Connector) Subscribe(topics []kafkautils.Topic, overrideOpts ...kafka.C
 		return nil, err
 	}
 
-	return c.Consumer.Messages, nil
+	return c.Consumer.Messages(), nil
 }
 
 func (c *Connector) SubscribeExample() error {

--- a/kafkautils/consumer.go
+++ b/kafkautils/consumer.go
@@ -9,7 +9,7 @@ import (
 
 type Consumer struct {
 	*kafka.Consumer
-	Messages <-chan Message
+	messages <-chan Message
 }
 
 // NewConsumer prepares a message queue consumer. Subscribe to proto messages on .Messages chan
@@ -46,9 +46,14 @@ func NewConsumer(brokers string, groupID string, overrideOpts ...kafka.ConfigMap
 	}
 
 	c := Consumer{Consumer: cons}
-	c.Messages = c.kafkaEventToProtoPipe(c.Events())
+	c.messages = c.kafkaEventToProtoPipe(c.Events())
 
 	return &c, nil
+}
+
+//	Messages returns receiver channel for Kafka messages.
+func (c *Consumer) Messages() <-chan Message {
+	return c.messages
 }
 
 // SubscribeTopics subscribes to the provided list of topics. This replaces the current subscription.

--- a/kafkautils/mocks/mock_producer.go
+++ b/kafkautils/mocks/mock_producer.go
@@ -64,6 +64,18 @@ func (mr *MockProducerInterfaceMockRecorder) BeginTransaction() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BeginTransaction", reflect.TypeOf((*MockProducerInterface)(nil).BeginTransaction))
 }
 
+// Close mocks base method.
+func (m *MockProducerInterface) Close() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Close")
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockProducerInterfaceMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockProducerInterface)(nil).Close))
+}
+
 // CommitTransaction mocks base method.
 func (m *MockProducerInterface) CommitTransaction(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -106,8 +118,22 @@ func (mr *MockProducerInterfaceMockRecorder) InitTransactions(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitTransactions", reflect.TypeOf((*MockProducerInterface)(nil).InitTransactions), arg0)
 }
 
+// MakeQueueTransactionSink mocks base method.
+func (m *MockProducerInterface) MakeQueueTransactionSink() chan *kafkautils.Message {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeQueueTransactionSink")
+	ret0, _ := ret[0].(chan *kafkautils.Message)
+	return ret0
+}
+
+// MakeQueueTransactionSink indicates an expected call of MakeQueueTransactionSink.
+func (mr *MockProducerInterfaceMockRecorder) MakeQueueTransactionSink() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeQueueTransactionSink", reflect.TypeOf((*MockProducerInterface)(nil).MakeQueueTransactionSink))
+}
+
 // WriteAndCommit mocks base method.
-func (m *MockProducerInterface) WriteAndCommit(arg0 string, arg1 []byte, arg2 protoreflect.ProtoMessage) error {
+func (m *MockProducerInterface) WriteAndCommit(arg0 kafkautils.Topic, arg1 []byte, arg2 protoreflect.ProtoMessage) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteAndCommit", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -133,7 +159,7 @@ func (mr *MockProducerInterfaceMockRecorder) WriteAndCommitSink(arg0 interface{}
 }
 
 // WriteKafkaMessages mocks base method.
-func (m *MockProducerInterface) WriteKafkaMessages(arg0 string, arg1 []byte, arg2 protoreflect.ProtoMessage) error {
+func (m *MockProducerInterface) WriteKafkaMessages(arg0 kafkautils.Topic, arg1 []byte, arg2 protoreflect.ProtoMessage) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WriteKafkaMessages", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/kafkautils/producer.go
+++ b/kafkautils/producer.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-//go:generate mockgen --build_flags='-tags dynamic' -destination=mocks/mock_producer.go -package=mocks . ProducerInterface
+//go:generate mockgen -destination=mocks/mock_producer.go -package=mocks . ProducerInterface
 type ProducerInterface interface {
 	InitTransactions(context.Context) error
 	BeginTransaction() error
@@ -187,9 +187,8 @@ func (p *Producer) Close() {
 	// Exit application with an error (1) if there was a fatal error.
 	if fatalErr != nil {
 		os.Exit(1)
-	} else {
-		os.Exit(0)
 	}
+	os.Exit(0)
 }
 
 // https://github.com/confluentinc/confluent-kafka-go/blob/24f06a50dd915cc346c8a36e5a7f7306f4339cfe/examples/transactions_example/txnhelpers.go


### PR DESCRIPTION
Existing mock is for the previous version. It breaks connector tests. This PR replaces it with the latest interface.