### PR TITLE
[EN-1236] Use ProducerInterface instead of Producer

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -27,7 +27,7 @@ type Connector struct {
 	kafkaUrl        string
 	producerStarted bool
 	consumerStarted bool
-	*kafkautils.Producer
+	kafkautils.ProducerInterface
 	*kafkautils.Consumer
 
 	ChainClients     *chain.Clients
@@ -165,17 +165,17 @@ func (c *Connector) ProduceAndCommitMessage(namespace, subject string, msg proto
 		return err
 	}
 
-	err = c.Producer.CommitTransaction(nil)
+	err = c.ProducerInterface.CommitTransaction(nil)
 	if err != nil {
 		log.Error().Err(err).Msg("Processor: Failed to commit transaction")
 
-		err = c.Producer.AbortTransaction(nil)
+		err = c.ProducerInterface.AbortTransaction(nil)
 		if err != nil {
 			log.Fatal().Err(err).Msg("")
 		}
 	}
 	// Start a new transaction
-	err = c.Producer.BeginTransaction()
+	err = c.ProducerInterface.BeginTransaction()
 	if err != nil {
 		log.Fatal().Err(err).Msg("")
 	}
@@ -191,12 +191,12 @@ func (c *Connector) startProducer() error {
 		Msg("Initializing kafka producer")
 
 	var err error
-	c.Producer, err = kafkautils.NewProducer(c.kafkaUrl, txID)
+	c.ProducerInterface, err = kafkautils.NewProducer(c.kafkaUrl, txID)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create new kafka producer")
 		return err
 	}
-	err = c.Producer.EnableTransactions()
+	err = c.ProducerInterface.EnableTransactions()
 	if err != nil {
 		return err
 	}

--- a/kafkautils/mocks/mock_producer.go
+++ b/kafkautils/mocks/mock_producer.go
@@ -118,20 +118,6 @@ func (mr *MockProducerInterfaceMockRecorder) InitTransactions(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitTransactions", reflect.TypeOf((*MockProducerInterface)(nil).InitTransactions), arg0)
 }
 
-// MakeQueueTransactionSink mocks base method.
-func (m *MockProducerInterface) MakeQueueTransactionSink() chan *kafkautils.Message {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeQueueTransactionSink")
-	ret0, _ := ret[0].(chan *kafkautils.Message)
-	return ret0
-}
-
-// MakeQueueTransactionSink indicates an expected call of MakeQueueTransactionSink.
-func (mr *MockProducerInterfaceMockRecorder) MakeQueueTransactionSink() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeQueueTransactionSink", reflect.TypeOf((*MockProducerInterface)(nil).MakeQueueTransactionSink))
-}
-
 // WriteAndCommit mocks base method.
 func (m *MockProducerInterface) WriteAndCommit(arg0 kafkautils.Topic, arg1 []byte, arg2 protoreflect.ProtoMessage) error {
 	m.ctrl.T.Helper()

--- a/kafkautils/producer.go
+++ b/kafkautils/producer.go
@@ -23,7 +23,6 @@ type ProducerInterface interface {
 	EnableTransactions() error
 	WriteAndCommitSink(<-chan *Message)
 	WriteAndCommit(Topic, []byte, proto.Message) error
-	MakeQueueTransactionSink() chan *Message
 	Close()
 }
 
@@ -297,17 +296,4 @@ func (p *Producer) WriteAndCommitSink(in <-chan *Message) {
 				Msg("Write to kafka error")
 		}
 	}
-}
-
-// MakeQueueTransactionSink creates a channel that receives Kafka Messages. All messages within the channel are then automatically
-// published to the specific topic in the `*kafkautils.Message`.
-func (p *Producer) MakeQueueTransactionSink() chan *Message {
-	sink := make(chan *Message, 10000)
-	err := p.EnableTransactions()
-	if err != nil {
-		log.Fatal().Err(err).Msg("Transaction was not enabled")
-	}
-	go p.WriteAndCommitSink(sink)
-
-	return sink
 }


### PR DESCRIPTION
refs: https://blep.atlassian.net/browse/EN-1236?atlOrigin=eyJpIjoiN2RiNDVhYWNmODdhNDFlZmJiZjdjMjAyYmZiZWMwYTYiLCJwIjoiaiJ9

Changes:
- removes MakeQueueTransactionSink
- replaces connector.Producer field with ProducerInterface so we can mock it out in our tests in blep.ai