### PR TITLE
Disable Kafka msg delivery chan

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -265,10 +265,6 @@ func (c *Connector) InitProduceChannel(input <-chan protoreflect.ProtoMessage) {
 	duration := time.Second * 1
 
 	ticker := time.NewTicker(duration)
-	delivery := make(chan kafka.Event)
-	defer close(delivery)
-
-	go c.ProducerInterface.ListenDeliveryChan(delivery)
 
 start:
 	hasMessage := false
@@ -325,7 +321,7 @@ start:
 
 			hasMessage = true
 			topic := c.generateTopicFromProto(msg)
-			c.ProducerInterface.ProduceMsg(topic, msg, nil, time.Time{}, delivery)
+			c.ProducerInterface.ProduceMsg(topic, msg, nil, time.Time{}, nil)
 		}
 	}
 }

--- a/connector.go
+++ b/connector.go
@@ -261,6 +261,8 @@ func (c *Connector) buildTopicTypes(protos ...proto.Message) protoregistry.Topic
 	return tt
 }
 
+//	InitProduceChannel uses the incoming messages from protobuf message channel and forwards them to Kafka.
+//	It wraps messages in Kafka Transactions to ensure Exactly Once Semantics.
 func (c *Connector) InitProduceChannel(input <-chan protoreflect.ProtoMessage) {
 	duration := time.Second * 1
 
@@ -312,6 +314,8 @@ start:
 						}
 					}
 				}
+
+				log.Info().Msg("successfully committed transactions")
 
 				ticker.Reset(duration)
 

--- a/kafkautils/key.go
+++ b/kafkautils/key.go
@@ -32,6 +32,9 @@ func (k Key) String() string {
 }
 
 func ParseKey(s []byte) (Key, error) {
+	if s == nil {
+		return Key{}, nil
+	}
 	k := strings.Split(string(s), KeyDelimiter)
 	if len(k) != 2 {
 		return Key{}, fmt.Errorf("Cannot parse key, needs 2 parts separated by \"%s\": %s", KeyDelimiter, string(s))

--- a/kafkautils/producer.go
+++ b/kafkautils/producer.go
@@ -371,6 +371,8 @@ func (p *Producer) ProduceMsg(topic Topic, msg proto.Message, key []byte, timest
 	return p.Produce(kafkaMsg, delivery)
 }
 
+//	ListenDeliveryChan processes acknowledgements from Kafka broker upon Produce() calls.
+//	Using this method will disable global event processing by the producer.
 func (p *Producer) ListenDeliveryChan(delivery chan kafka.Event) {
 	for e := range delivery {
 		switch ev := e.(type) {


### PR DESCRIPTION
- Update kafka lib to accept messages without key.
- Including a delivery channel bypasses global event processing. This PR removes that channel.