### PR TITLE
[EN-1471] Automate event produce channel

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -35,6 +35,7 @@ type Connector struct {
 	Health           healthcheck.Handler
 	MsgType          kafkautils.MsgType
 	ProtoRegistryCli *protoregistry.Client
+	Sink             chan protoreflect.ProtoMessage
 }
 
 // NewConnector returns a base connector implementation that other connectors can embed to add on to.

--- a/subscription.go
+++ b/subscription.go
@@ -210,7 +210,7 @@ func (s *Subscription) subscribeLogs() {
 	logch := make(chan types.Log)
 	subErrChan, err := chain.ChunkedSubscribeFilterLogs(s.context, s.client, q, logch, 0)
 	if err != nil {
-		log.Fatal().Msg("failed to subscribe to event logs")
+		log.Fatal().Err(err).Msg("failed to subscribe to event logs")
 	}
 
 	tWait := time.Second
@@ -282,11 +282,13 @@ func isRetryable(err error) bool {
 	// error 2: Connection reset by peer
 	// error 3: websocket: close 1006 (abnormal closure)
 	// error 4: unexpected EOF
+	// error 5: websocket: close 1001 (going away): upstream went away
 	if err == nil {
 		return false
 	}
 	return strings.Contains(err.Error(), "timed") ||
 		strings.Contains(err.Error(), "reset") ||
 		strings.Contains(err.Error(), "1006") ||
-		strings.Contains(err.Error(), "EOF")
+		strings.Contains(err.Error(), "EOF") ||
+		strings.Contains(err.Error(), "1001")
 }


### PR DESCRIPTION
This PR will create a kafka Produce channel in its constructor automatically.
There are also minor changes as:
- Add error log to RPC subscription fatal errors
- Handle RPC go away error