### PR TITLE
Remove duplicate kafka produce msg functions

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -337,7 +337,7 @@ func (c *Connector) initProduceChannel(input <-chan protoreflect.ProtoMessage) {
 
 			hasMessage = true
 			topic := c.generateTopicFromProto(msg)
-			c.ProducerInterface.ProduceMsg(topic, msg, nil, nil)
+			c.ProducerInterface.ProduceMsg(topic.String(), msg, nil, nil)
 		}
 	}
 }

--- a/connector.go
+++ b/connector.go
@@ -160,7 +160,7 @@ func (c *Connector) SubscribeExample() error {
 func (c *Connector) ProduceMessage(namespace, subject string, msg proto.Message) error {
 	topic := c.generateTopicFromProto(msg)
 	key := kafkautils.NewKey(namespace, subject)
-	return c.WriteKafkaMessages(topic, key.Bytes(), msg)
+	return c.ProduceMsg(topic.String(), msg, key.Bytes(), nil)
 }
 
 // ProduceAndCommitMessage sends protobuf to message queue with a Topic and Key.

--- a/kafkautils/mocks/mock_producer.go
+++ b/kafkautils/mocks/mock_producer.go
@@ -146,7 +146,7 @@ func (mr *MockProducerInterfaceMockRecorder) MakeQueueTransactionSink() *gomock.
 }
 
 // ProduceMsg mocks base method.
-func (m *MockProducerInterface) ProduceMsg(arg0 kafkautils.Topic, arg1 protoreflect.ProtoMessage, arg2 []byte, arg3 chan kafka.Event) error {
+func (m *MockProducerInterface) ProduceMsg(arg0 string, arg1 protoreflect.ProtoMessage, arg2 []byte, arg3 chan kafka.Event) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProduceMsg", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)
@@ -183,18 +183,4 @@ func (m *MockProducerInterface) WriteAndCommitSink(arg0 <-chan *kafkautils.Messa
 func (mr *MockProducerInterfaceMockRecorder) WriteAndCommitSink(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteAndCommitSink", reflect.TypeOf((*MockProducerInterface)(nil).WriteAndCommitSink), arg0)
-}
-
-// WriteKafkaMessages mocks base method.
-func (m *MockProducerInterface) WriteKafkaMessages(arg0 kafkautils.Topic, arg1 []byte, arg2 protoreflect.ProtoMessage) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteKafkaMessages", arg0, arg1, arg2)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// WriteKafkaMessages indicates an expected call of WriteKafkaMessages.
-func (mr *MockProducerInterfaceMockRecorder) WriteKafkaMessages(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteKafkaMessages", reflect.TypeOf((*MockProducerInterface)(nil).WriteKafkaMessages), arg0, arg1, arg2)
 }


### PR DESCRIPTION
Removes `WriteKafkaMessages()` and points callers to `ProduceMsg()` function. They are basically doing the same thing.