### PR TITLE
[EN-1503] Refactor solana client

### DIFF
--- a/chain/solana.go
+++ b/chain/solana.go
@@ -2,26 +2,408 @@ package chain
 
 import (
 	"context"
+	"strings"
+	"time"
 
+	"github.com/nakji-network/connector/config"
+
+	"github.com/avast/retry-go"
+	bin "github.com/gagliardetto/binary"
+	token_metadata "github.com/gagliardetto/metaplex-go/clients/token-metadata"
+	"github.com/gagliardetto/solana-go"
+	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/gagliardetto/solana-go/programs/token"
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/gagliardetto/solana-go/rpc/ws"
 	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 const chain = "solana"
 
 // Config yaml(local.yaml) file must include the following
 //	rpcs:
-//		solana:
-//			url: https://rpcprovider.com/
+//	  solana:
+//		full:
+//		  -wss://rpcprovider.com/
+//		  -https://rpcprovider.com/
 
-func (c Clients) Solana() (*rpc.Client, *ws.Client) {
-	client := rpc.New(c.rpcMap[chain].Url)
+type (
+	rpcClient = *rpc.Client
+	wsClient  = *ws.Client
+)
 
-	wsClient, err := ws.Connect(context.Background(), c.rpcMap[chain].Url)
+type SolanaClient struct {
+	rpcClient
+	wsClient
+	Config *viper.Viper
+}
+
+func initConfig() *viper.Viper {
+	conf := config.GetConfig()
+
+	conf.SetDefault("solana.maxRetries", 10)
+	conf.SetDefault("solana.retryDelay", 500)
+	conf.SetDefault("solana.lowPrioRetryDelay", 3)
+	conf.SetDefault("solana.lowPrioMaxRetries", 100)
+
+	return conf
+}
+
+// TODO: The ws client is not being used. Need to look into it.
+func (c Clients) Solana() *SolanaClient {
+	conf := initConfig()
+
+	rpcs := c.rpcMap[chain].Full
+
+	var wsURL, httpURL string
+	for _, u := range rpcs {
+		if strings.HasPrefix(u, "ws") {
+			wsURL = u
+		} else {
+			httpURL = u
+		}
+	}
+	log.Info().
+		Str("chain", chain).
+		Str("ws url", wsURL).
+		Str("http url", httpURL).
+		Msg("connecting to RPC")
+
+	rpcCli := rpc.New(httpURL)
+
+	wsCli, err := ws.Connect(context.Background(), wsURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Solana: WS Client connection error")
 	}
 
-	return client, wsClient
+	return &SolanaClient{rpcCli, wsCli, conf}
+}
+
+// ProgramListener listens for Signatures from the latest Solana block that mention the given `programId`
+// and gets all Transaction data related for each of those signatures. `processTransaction`
+// is where custom logic comes in for the specific program connector. This usually gets
+// and decodes all instructions data from the transaction and emits/publishes events
+// based on those decoded instructions.
+// NOTE THAT IT IS NOT USING WS CLIENT !!!
+func (sc *SolanaClient) ProgramListener(ctx context.Context, programId solana.PublicKey, namespace string, processTransaction func(*rpc.GetTransactionResult, *solana.Transaction, solana.Signature)) {
+	var lastTxSig solana.Signature
+	limit := 50
+	opts := &rpc.GetSignaturesForAddressOpts{Limit: &limit}
+
+	for {
+		if !lastTxSig.IsZero() {
+			opts.Until = lastTxSig
+		}
+		signatures, _ := sc.GetSignaturesForAddressWithOpts(context.Background(), programId, opts)
+
+		if len(signatures) > 0 {
+			lastTxSig = signatures[0].Signature
+		}
+
+		for _, txSignature := range signatures {
+			signature := txSignature.Signature
+			txResult, tx := sc.GetTransaction(ctx, signature)
+
+			log.Debug().Msgf("%s : processing transaction %s", namespace, signature.String())
+			processTransaction(txResult, tx, signature)
+		}
+
+		time.Sleep(time.Millisecond * 500)
+	}
+}
+
+// ProgramBackfiller backfills all events/instructions using checkpointing. We use the last processed transaction's signature as
+// the checkpoint. On next start of the program, we continue backfilling from that checkpoint. This also backfills
+// until `backfillTxLimit` to backfill any missed transactions when the connector was down.
+//func (sc *SolanaClient) ProgramBackfiller(ctx context.Context, programId solana.PublicKey, namespace string, processTransaction func(*rpc.GetTransactionResult, *solana.Transaction, solana.Signature), backfillLimit int) {
+//	_, backfillCompleted := sc.getSignaturesForAddressOpts(namespace)
+//
+//	if backfillCompleted {
+//		log.Info().Msgf("backfill already completed for %s", namespace)
+//		return
+//	}
+//
+//	var once sync.Once
+//
+//	go once.Do(func() {
+//		log.Debug().Msgf("backfilling last %d transactions", backfillLimit)
+//		opts := &rpc.GetSignaturesForAddressOpts{Limit: &backfillLimit}
+//		sc.backfill(ctx, programId, namespace, processTransaction, false, opts)
+//	})
+//
+//	for opts, backfillCompleted := sc.getSignaturesForAddressOpts(namespace); !backfillCompleted; {
+//		sc.backfill(ctx, programId, namespace, processTransaction, true, opts)
+//	}
+//}
+//
+//func (sc *SolanaClient) backfill(ctx context.Context, programId solana.PublicKey, namespace string, processTransaction func(*rpc.GetTransactionResult, *solana.Transaction, solana.Signature), storeCheckpoint bool, opts *rpc.GetSignaturesForAddressOpts) {
+//	var txSignatures []*rpc.TransactionSignature
+//
+//	for retries := 0; retries < 5 && len(txSignatures) == 0; retries++ {
+//		var err error
+//		txSignatures, err = sc.GetSignaturesForAddressWithOpts(ctx, programId, opts)
+//		if err != nil {
+//			log.Fatal().Err(err).Str("program", programId.String()).Msg("failed getting signatures for program in backfill")
+//		}
+//
+//		if len(txSignatures) > 0 {
+//			break
+//		}
+//
+//		time.Sleep(500 * time.Millisecond)
+//	}
+//
+//	// We want to end the loop when there are no signatures/transactions left
+//	if len(txSignatures) == 0 {
+//		sc.Db.UpdateBackfillCompleted(namespace, true)
+//		return
+//	}
+//
+//	for _, txSignature := range txSignatures {
+//		signature := txSignature.Signature
+//		log.Debug().Msgf("%s : backfilling transaction %s", namespace, signature.String())
+//		txResult, tx := sc.GetTransaction(ctx, signature)
+//		processTransaction(txResult, tx, signature)
+//		if storeCheckpoint {
+//			// We store the last signature we published events for so we can use as checkpoint later on.
+//			sc.Db.UpsertLastTxSignatureQueried(namespace, signature.String())
+//		}
+//	}
+//}
+//
+//func (sc *SolanaClient) getSignaturesForAddressOpts(namespace string) (*rpc.GetSignaturesForAddressOpts, bool) {
+//	lastSignature := sc.Db.GetLastTxSignatureQueried(namespace)
+//	limit := 500
+//	opts := &rpc.GetSignaturesForAddressOpts{Limit: &limit}
+//
+//	if lastSignature != nil {
+//		log.Info().Msgf("starting backfill from checkpoint %s for %s", lastSignature.Signature, namespace)
+//		opts.Before = solana.MustSignatureFromBase58(lastSignature.Signature)
+//		return opts, lastSignature.BackfillCompleted
+//	}
+//
+//	return opts, false
+//}
+
+func (sc *SolanaClient) GetTransaction(ctx context.Context, signature solana.Signature) (*rpc.GetTransactionResult, *solana.Transaction) {
+	opts := &rpc.GetTransactionOpts{Commitment: rpc.CommitmentFinalized, Encoding: solana.EncodingBase64}
+	var txResult *rpc.GetTransactionResult
+
+	err := sc.withRetry(
+		func() error {
+			var err error
+			txResult, err = sc.rpcClient.GetTransaction(ctx, signature, opts)
+			return err
+		}, "GetTransaction", map[string]string{"txSignature": signature.String()},
+	)
+
+	if err != nil {
+		log.Fatal().Err(err).Msgf("failed getting transaction: %s", signature)
+	}
+
+	decoder := bin.NewBinDecoder(txResult.Transaction.GetBinary())
+	tx, err := solana.TransactionFromDecoder(decoder)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed decoding transaction")
+	}
+
+	return txResult, tx
+}
+
+func logHasError(logResult *ws.LogResult) bool {
+	return HasError(logResult.Value.Err)
+}
+
+func HasError(err interface{}) bool {
+	switch err.(type) {
+	case map[string]interface{}:
+		return true
+	case nil:
+		return false
+	default:
+		return false
+	}
+}
+
+// Get and decode Mint data given a Mint address
+func (sc *SolanaClient) GetMint(ctx context.Context, mintPubKey solana.PublicKey) *token.Mint {
+	var mint token.Mint
+
+	err := sc.withRetry(
+		func() error {
+			err := sc.GetAccountDataBorshInto(ctx, mintPubKey, &mint)
+			return err
+		}, "GetMint", map[string]string{"mint": mintPubKey.String()},
+	)
+
+	if err != nil {
+		log.Fatal().Interface("mintPubKey", mintPubKey).Err(err).Msg("failed getting token mint account")
+	}
+
+	return &mint
+}
+
+// Get and decode Token Metadata given a Mint address. Only works for NFT Mints.
+func (sc *SolanaClient) GetMetadata(ctx context.Context, mintPubKey solana.PublicKey) (*token_metadata.Metadata, error) {
+	metaPubKey, _, err := solana.FindTokenMetadataAddress(mintPubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var meta token_metadata.Metadata
+	err = sc.withRetry(
+		func() error {
+			err := sc.GetAccountDataBorshInto(ctx, metaPubKey, &meta)
+			return err
+		}, "GetMeta", map[string]string{"metadata": metaPubKey.String()},
+		retry.Delay(sc.lowPrioRetryDelay()),
+		retry.Attempts(sc.lowPrioRetryAttempts()),
+	)
+
+	if err != nil {
+		return &meta, err
+	}
+
+	return &meta, nil
+}
+
+func (sc *SolanaClient) GetNFTTokenAccount(ctx context.Context, tokenMint solana.PublicKey) *token.Account {
+	tokenAccountsResult, err := sc.GetTokenLargestAccounts(ctx, tokenMint, rpc.CommitmentFinalized)
+	if err != nil {
+		log.Fatal().Err(err).Str("mint", tokenMint.String()).Msg("failed getting associated token accounts")
+	}
+
+	address := tokenAccountsResult.Value[0].Address
+	tokenAccount, err := sc.GetTokenAccount(ctx, address)
+	if err != nil {
+		log.Fatal().Err(err).Str("tokenAccount", address.String()).Msg("failed getting NFT token account")
+	}
+
+	return tokenAccount
+}
+
+func (sc *SolanaClient) GetTokenAccount(ctx context.Context, pubKey solana.PublicKey) (*token.Account, error) {
+	var tokenAccount token.Account
+
+	err := sc.withRetry(
+		func() error {
+			err := sc.GetAccountDataInto(ctx, pubKey, &tokenAccount)
+			return err
+		}, "GetTokenAccount", map[string]string{"tokenAccount": pubKey.String()},
+		retry.Delay(sc.lowPrioRetryDelay()),
+		retry.Attempts(sc.lowPrioRetryAttempts()),
+	)
+
+	return &tokenAccount, err
+}
+
+// Fetches and parses all SPL-Token Program instructions and inner instructions from all transaction data.
+// The returned slice preserves the ordering of these Token Program instructions in the transaction.
+func (sc *SolanaClient) GetTokenInstructions(txResult *rpc.GetTransactionResult, tx *solana.Transaction) []*token.Instruction {
+	accountKeys := tx.Message.AccountKeys
+	var (
+		tokenProgramIdIdx uint16
+		tokenInstructions []*token.Instruction
+	)
+
+	for i, publicKey := range accountKeys {
+		if publicKey.String() == solana.TokenProgramID.String() {
+			tokenProgramIdIdx = uint16(i)
+			break
+		}
+	}
+
+	// This map preserves the ordering of instructions and inner instructions within a transaction.
+	// This is important since Solana uses that as basis for the order of their execution. The map's
+	// key is the parent instruction's index within the transaction.
+	innerInstructionsIndexMap := make(map[uint16]rpc.InnerInstruction)
+	for _, innerInstruction := range txResult.Meta.InnerInstructions {
+		innerInstructionsIndexMap[innerInstruction.Index] = innerInstruction
+	}
+
+	for i, instruction := range tx.Message.Instructions {
+		// Check if the parent instruction is an SPL-Token Program instruction.
+		// Add that to `tokenInstructions` slice, if it is.
+		if instruction.ProgramIDIndex == tokenProgramIdIdx {
+			tokenInstruction, _ := DecodeTokenInstruction(instruction, tx)
+			tokenInstructions = append(tokenInstructions, tokenInstruction)
+		}
+
+		// If the inner instruction's index matches the current index, we check if any of these
+		// inner instructions are SPL-Token Program instructions and add them to `tokenInstructions`.
+		if innerInstruction, ok := innerInstructionsIndexMap[uint16(i)]; ok {
+			for _, instruction := range innerInstruction.Instructions {
+				if instruction.ProgramIDIndex == tokenProgramIdIdx {
+					tokenInstruction, _ := DecodeTokenInstruction(instruction, tx)
+					tokenInstructions = append(tokenInstructions, tokenInstruction)
+				}
+			}
+		}
+	}
+
+	return tokenInstructions
+}
+
+// DecodeSystemInstruction decodes a `solana.CompiledInstruction` into a `*system.Instruction` which represents an Instruction
+// from the System Program in Solana.
+func DecodeSystemInstruction(instruction solana.CompiledInstruction, tx *solana.Transaction) (*system.Instruction, error) {
+	accountMetas := instruction.ResolveInstructionAccounts(&tx.Message)
+	systemInstruction, err := system.DecodeInstruction(accountMetas, instruction.Data)
+	if err != nil {
+		return nil, err
+	}
+	return systemInstruction, nil
+}
+
+// DecodeTokenInstruction decodes a `solana.CompiledInstruction` into a `*token.Instruction` which represents an Instruction
+// from the SPL-Token Program in Solana.
+func DecodeTokenInstruction(instruction solana.CompiledInstruction, tx *solana.Transaction) (*token.Instruction, error) {
+	accountMetas := instruction.ResolveInstructionAccounts(&tx.Message)
+	tokenInstruction, err := token.DecodeInstruction(accountMetas, instruction.Data)
+	if err != nil {
+		return nil, err
+	}
+	return tokenInstruction, nil
+}
+
+func (sc *SolanaClient) withRetry(retryFunc retry.RetryableFunc, funcName string, logs map[string]string, opts ...retry.Option) error {
+	maxRetries := sc.Config.GetUint("solana.maxRetries")
+	retryDelay := sc.Config.GetInt("solana.retryDelay")
+
+	if len(opts) == 0 {
+		opts = append(
+			opts,
+			retry.Delay(time.Duration(retryDelay)*time.Millisecond),
+			retry.Attempts(maxRetries),
+		)
+	}
+
+	opts = append(
+		opts,
+		retry.OnRetry(func(n uint, err error) {
+			logEvent := log.Warn().Err(err).Uint("retries", n)
+			for key, val := range logs {
+				logEvent = logEvent.Str(key, val)
+			}
+			if n < maxRetries {
+				logEvent.Msgf("%s Error", funcName)
+			} else {
+				logEvent.Msgf("%s Error Max Retry", funcName)
+			}
+		}),
+	)
+
+	err := retry.Do(retryFunc, opts...)
+
+	return err
+}
+
+func (sc *SolanaClient) lowPrioRetryDelay() time.Duration {
+	maxRetries := sc.Config.GetInt("solana.lowPrioRetryDelay")
+	return time.Duration(maxRetries) * time.Millisecond
+}
+
+func (sc *SolanaClient) lowPrioRetryAttempts() uint {
+	return sc.Config.GetUint("solana.lowPrioMaxRetries")
 }

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,13 @@ go 1.18
 
 require (
 	github.com/Masterminds/semver v1.5.0
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/ethereum/go-ethereum v1.10.15
-	github.com/gagliardetto/solana-go v1.1.0
+	github.com/gagliardetto/binary v0.6.1
+	github.com/gagliardetto/metaplex-go v0.2.1
+	github.com/gagliardetto/solana-go v1.4.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
@@ -41,7 +44,6 @@ require (
 	github.com/dfuse-io/logging v0.0.0-20210109005628-b97a57253f70 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
-	github.com/gagliardetto/binary v0.6.1 // indirect
 	github.com/gagliardetto/treeout v0.1.4 // indirect
 	github.com/go-ole/go-ole v1.2.1 // indirect
 	github.com/go-stack/stack v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VT
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.22.1/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go-v2 v1.2.0/go.mod h1:zEQs02YRBw1DjK0PoJv3ygDYOFTre1ejlJWl8FwAuQo=
@@ -112,6 +114,7 @@ github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792 h1:R8vQdOQdZ9Y3SkEwmHoWBmX1DNXhXZqlTpq6s4tyJGc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/buger/goterm v0.0.0-20200322175922-2f3e71b85129/go.mod h1:u9UyCz2eTrSGy6fbupqJ54eY5c4IC8gREQ1053dK12U=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
@@ -187,11 +190,16 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gagliardetto/binary v0.6.1 h1:vGrbUym10xaaswadfnuSDr0xlP3NZS5XWbLqENJidrI=
 github.com/gagliardetto/binary v0.6.1/go.mod h1:aOfYkc20U0deHaHn/LVZXiqlkDbFAX0FpTlDhsXa0S0=
+github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=
 github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
-github.com/gagliardetto/solana-go v1.1.0 h1:iue265g6K45Mhr4yV20r55Y3a5jnuOS5VtslducI5Os=
-github.com/gagliardetto/solana-go v1.1.0/go.mod h1:vhaJ8hSOXJamo+Eh9kpD/TeuvF6rLWBzD7LU9xg9vbk=
+github.com/gagliardetto/hashsearch v0.0.0-20191005111333-09dd671e19f9/go.mod h1:513DXpQPzeRo7d4dsCP3xO3XI8hgvruMl9njxyQeraQ=
+github.com/gagliardetto/metaplex-go v0.2.1 h1:NMBsgJe3I2avKZ39dfYQvXsGsr2BxUgARkA9LZ6szBg=
+github.com/gagliardetto/metaplex-go v0.2.1/go.mod h1:6ZLYBvlWcXktXQ/QcBJYRzKgK7Q3WgiGD7BjE7Zxpw4=
+github.com/gagliardetto/solana-go v1.4.0 h1:B6O4F7ZyOHLmZTF0jvJQZohriVwo15vo5XKJQWMbbWM=
+github.com/gagliardetto/solana-go v1.4.0/go.mod h1:NFuoDwHPvw858ZMHUJr6bkhN8qHt4x6e+U3EYHxAwNY=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=
 github.com/gagliardetto/treeout v0.1.4/go.mod h1:loUefvXTrlRG5rYmJmExNryyBRh8f89VZhmMOyCyqok=
+github.com/gagliardetto/utilz v0.1.1/go.mod h1:b+rGFkRHz3HWJD0RYMzat47JyvbTtpE0iEcYTRJTLLA=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff h1:tY80oXqGNY4FhTFhk+o9oFHGINQ/+vhlm8HFzi6znCI=
 github.com/gballet/go-libpcsclite v0.0.0-20190607065134-2772fd86a8ff/go.mod h1:x7DCsMOv1taUwEWCzT4cmDeAkigA5/QCwUodaVOe8Ww=
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
@@ -298,6 +306,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
+github.com/hako/durafmt v0.0.0-20200710122514-c0fb7b4da026/go.mod h1:5Scbynm8dF1XAPwIwkGPqzkM/shndPm79Jd1003hTjE=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -435,6 +444,7 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.35/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -539,6 +549,7 @@ github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/segmentio/kafka-go v0.1.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
 github.com/segmentio/kafka-go v0.2.0/go.mod h1:X6itGqS9L4jDletMsxZ7Dz+JFWxM6JHfPOCvTvk+EJo=
@@ -778,6 +789,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Temporarily refactor it to use `connector` lib and disable the backfill feature, because it is not using ws client somehow. Currently it's using http polling to get the block data, we need to do more refactoring work on it in the future. 