### PR TITLE
[EN-1502] Refactor manifest creation for legacy connectors

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -70,6 +70,10 @@ func NewConnector(options ...Option) (*Connector, error) {
 
 	parseOptions(c, options...)
 
+	if c.manifest == nil {
+		log.Fatal().Msg("missing manifest.yaml")
+	}
+
 	c.Config = conf.Sub(c.id())
 	if c.Config == nil {
 		c.Config = viper.New()

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/confluentinc/confluent-kafka-go v1.8.2
 	github.com/ethereum/go-ethereum v1.10.15
 	github.com/gagliardetto/binary v0.6.1
-	github.com/gagliardetto/metaplex-go v0.2.1
-	github.com/gagliardetto/solana-go v1.4.0
+	github.com/gagliardetto/metaplex-go v0.2.0
+	github.com/gagliardetto/solana-go v1.1.0
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d

--- a/go.sum
+++ b/go.sum
@@ -193,10 +193,10 @@ github.com/gagliardetto/binary v0.6.1/go.mod h1:aOfYkc20U0deHaHn/LVZXiqlkDbFAX0F
 github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=
 github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
 github.com/gagliardetto/hashsearch v0.0.0-20191005111333-09dd671e19f9/go.mod h1:513DXpQPzeRo7d4dsCP3xO3XI8hgvruMl9njxyQeraQ=
-github.com/gagliardetto/metaplex-go v0.2.1 h1:NMBsgJe3I2avKZ39dfYQvXsGsr2BxUgARkA9LZ6szBg=
-github.com/gagliardetto/metaplex-go v0.2.1/go.mod h1:6ZLYBvlWcXktXQ/QcBJYRzKgK7Q3WgiGD7BjE7Zxpw4=
-github.com/gagliardetto/solana-go v1.4.0 h1:B6O4F7ZyOHLmZTF0jvJQZohriVwo15vo5XKJQWMbbWM=
-github.com/gagliardetto/solana-go v1.4.0/go.mod h1:NFuoDwHPvw858ZMHUJr6bkhN8qHt4x6e+U3EYHxAwNY=
+github.com/gagliardetto/metaplex-go v0.2.0 h1:ftQ+/a7+ANhueuLpgtvfKAaJ/lmrrcHu5WpZqmmdifM=
+github.com/gagliardetto/metaplex-go v0.2.0/go.mod h1:+/Iw+z8WMDN2n9BhVGQuh6i+xp6eY+pjY1GAaXzViTQ=
+github.com/gagliardetto/solana-go v1.1.0 h1:iue265g6K45Mhr4yV20r55Y3a5jnuOS5VtslducI5Os=
+github.com/gagliardetto/solana-go v1.1.0/go.mod h1:vhaJ8hSOXJamo+Eh9kpD/TeuvF6rLWBzD7LU9xg9vbk=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=
 github.com/gagliardetto/treeout v0.1.4/go.mod h1:loUefvXTrlRG5rYmJmExNryyBRh8f89VZhmMOyCyqok=
 github.com/gagliardetto/utilz v0.1.1/go.mod h1:b+rGFkRHz3HWJD0RYMzat47JyvbTtpE0iEcYTRJTLLA=

--- a/manifest.go
+++ b/manifest.go
@@ -22,7 +22,7 @@ func LoadManifest() *manifest {
 
 	yfile, err := ioutil.ReadFile("manifest.yaml")
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to open file manifest.yaml.")
+		log.Warn().Err(err).Msg("Failed to open file manifest.yaml.")
 		return nil
 	}
 
@@ -46,7 +46,7 @@ func LoadManifest() *manifest {
 	return m
 }
 
-func CreateManifest(name string, author string, ver string) *manifest {
+func NewManifest(name string, author string, ver string) *manifest {
 	nv, err := semver.NewVersion(ver)
 	if err != nil {
 		log.Fatal().Err(err).Msg("invalid version")

--- a/manifest.go
+++ b/manifest.go
@@ -4,6 +4,7 @@ package connector
 import (
 	"io/ioutil"
 
+	"github.com/Masterminds/semver"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v3"
 )
@@ -21,7 +22,8 @@ func LoadManifest() *manifest {
 
 	yfile, err := ioutil.ReadFile("manifest.yaml")
 	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to open file manifest.yaml.")
+		log.Error().Err(err).Msg("Failed to open file manifest.yaml.")
+		return nil
 	}
 
 	m := new(manifest)
@@ -42,4 +44,17 @@ func LoadManifest() *manifest {
 		Msg("Manifest loaded")
 
 	return m
+}
+
+func CreateManifest(name string, author string, ver string) *manifest {
+	nv, err := semver.NewVersion(ver)
+	if err != nil {
+		log.Fatal().Err(err).Msg("invalid version")
+	}
+
+	return &manifest{
+		Name:    name,
+		Author:  author,
+		Version: version{nv},
+	}
 }


### PR DESCRIPTION
It's hard to migrate some legacy connectors to the new repo, so we need a way to create manifest manually.