### PR TITLE
[COR-126] Get rid of nfs server

### DIFF
--- a/protoregistry/client.go
+++ b/protoregistry/client.go
@@ -3,15 +3,26 @@ package protoregistry
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
+	"strings"
 
+	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/nakji-network/connector/kafkautils"
+)
+
+var (
+	errProtoFound    = errors.New("found the proto file")
+	errProtoNotFound = errors.New("failed to the proto file")
 )
 
 type Client struct {
@@ -26,8 +37,13 @@ func NewClient(host string) *Client {
 type TopicTypes map[string]proto.Message
 
 // RegisterDynamicTopics registers kafka topic and protobuf type mappings
-func (c *Client) RegisterDynamicTopics(topicTypes TopicTypes, msgType kafkautils.MsgType) error {
+func (c *Client) RegisterDynamicTopics(topicTypes map[string]proto.Message, msgType kafkautils.MsgType) error {
 	tpmList := buildTopicProtoMsgs(topicTypes, msgType)
+
+	err := generateDescriptorFiles(tpmList)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to generate descriptor files")
+	}
 
 	u := url.URL{Scheme: "http", Host: c.host, Path: "/v1/register"}
 
@@ -59,6 +75,7 @@ type TopicProtoMsg struct {
 	MsgType      kafkautils.MsgType `json:"msg_type" binding:"required"`
 	TopicName    string             `json:"topic" binding:"required"`
 	ProtoMsgName string             `json:"proto_msg" binding:"required"`
+	Descriptor   []byte             `json:"descriptor" binding:"required"`
 }
 
 type TopicSubscription struct {
@@ -66,8 +83,8 @@ type TopicSubscription struct {
 	ShouldUpdate   bool `json:"should_update"`
 }
 
-func buildTopicProtoMsgs(topicTypes TopicTypes, msgType kafkautils.MsgType) []TopicProtoMsg {
-	var tpmList []TopicProtoMsg
+func buildTopicProtoMsgs(topicTypes TopicTypes, msgType kafkautils.MsgType) []*TopicProtoMsg {
+	var tpmList []*TopicProtoMsg
 
 	for k, v := range topicTypes {
 		t := reflect.TypeOf(v)
@@ -78,7 +95,7 @@ func buildTopicProtoMsgs(topicTypes TopicTypes, msgType kafkautils.MsgType) []To
 			pmn = elem.String()
 		}
 
-		tpm := TopicProtoMsg{
+		tpm := &TopicProtoMsg{
 			MsgType:      msgType,
 			TopicName:    k,
 			ProtoMsgName: pmn,
@@ -87,4 +104,102 @@ func buildTopicProtoMsgs(topicTypes TopicTypes, msgType kafkautils.MsgType) []To
 		tpmList = append(tpmList, tpm)
 	}
 	return tpmList
+}
+
+// generateDescriptorFiles scans the local disk looking for proto files and generates proto descriptor files.
+func generateDescriptorFiles(tpmList []*TopicProtoMsg) error {
+	wd, err := os.Getwd()
+	if err != nil {
+		log.Error().Err(err).Msg("failed to call os.Getwd()")
+		return err
+	}
+
+	for _, tpm := range tpmList {
+		path, err := getProtoFilePath(wd, tpm)
+		if err != nil {
+			log.Error().Err(err).Interface("tpm", tpm).Msg("failed to get the proto file path")
+			return err
+		}
+
+		descFile, err := generateDescriptorFile(path)
+		if err != nil {
+			log.Error().Str("path", path).Str("descFile", descFile).Err(err).Msg("failed to generate descriptor file")
+			return err
+		}
+
+		desc, err := ioutil.ReadFile(descFile)
+		if err != nil {
+			log.Error().Err(err).Msg("failed to read descriptor file")
+			return err
+		}
+
+		tpm.Descriptor = desc
+	}
+
+	return nil
+}
+
+func generateDescriptorFile(path string) (string, error) {
+	descFile := path + ".desc"
+	file := filepath.Base(path)
+	dir := filepath.Dir(path)
+
+	_, err := os.Stat(descFile)
+	if err == nil {
+		log.Debug().Str("descFile", descFile).Msg("proto descriptor already exists, skip")
+		return descFile, nil
+	}
+
+	cmd := exec.Command(
+		"protoc",
+		"--include_imports",
+		"--descriptor_set_out="+descFile,
+		"-I="+dir,
+		file,
+	)
+
+	log.Debug().Str("path", path).Msg("generateDescriptorFile()")
+	log.Debug().Str("descFile", descFile).Msg("generateDescriptorFile()")
+
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	return descFile, nil
+}
+
+func getProtoFilePath(baseDir string, tpm *TopicProtoMsg) (string, error) {
+	pSeg := strings.Split(tpm.ProtoMsgName, kafkautils.TopicContextSeparator)
+	pkg := pSeg[0]
+
+	p := ""
+
+	err := filepath.WalkDir(baseDir, func(path string, info os.DirEntry, err error) error {
+		if err != nil {
+			log.Error().Err(err).Msg("WalkDirFunc error")
+			return err
+		}
+
+		// terminate the lookup if the file is found
+		if !info.IsDir() && filepath.Base(path) == pkg+".proto" {
+			p = path
+			log.Debug().Str("path", path).Msg("found the proto file")
+			return errProtoFound
+		}
+
+		return nil
+	})
+
+	if err == errProtoFound {
+		return p, nil
+	}
+
+	if err != nil {
+		log.Error().Err(err).Msg("WalkDir error")
+		return "", err
+	}
+
+	return "", errProtoNotFound
 }

--- a/protoregistry/prtest/prtest.proto.desc
+++ b/protoregistry/prtest/prtest.proto.desc
@@ -1,0 +1,61 @@
+
+ÿ
+google/protobuf/timestamp.protogoogle.protobuf";
+	Timestamp
+seconds (Rseconds
+nanos (RnanosB…
+com.google.protobufBTimestampProtoPZ2google.golang.org/protobuf/types/known/timestamppbø¢GPBªGoogle.Protobuf.WellKnownTypesbproto3
+¯
+
+prtest.protoprtestgoogle/protobuf/timestamp.proto"Â
+Mint*
+ts (2.google.protobuf.TimestampRts
+block (Rblock
+idx (Ridx
+tx (Rtx
+minter (Rminter
+
+mintAmount (R
+mintAmount
+
+mintTokens (R
+mintTokens"Ð
+Redeem*
+ts (2.google.protobuf.TimestampRts
+block (Rblock
+idx (Ridx
+tx (Rtx
+redeemer (Rredeemer"
+redeemAmount (RredeemAmount"
+redeemTokens (RredeemTokens"ø
+Borrow*
+ts (2.google.protobuf.TimestampRts
+block (Rblock
+idx (Ridx
+tx (Rtx
+borrower (Rborrower"
+borrowAmount (RborrowAmount&
+accountBorrows (RaccountBorrows"
+totalBorrows (RtotalBorrows"‘
+RepayBorrow*
+ts (2.google.protobuf.TimestampRts
+block (Rblock
+idx (Ridx
+tx (Rtx
+payer (Rpayer
+borrower (Rborrower 
+repayAmount (RrepayAmount&
+accountBorrows (RaccountBorrows"
+totalBorrows	 (RtotalBorrows"¡
+LiquidateBorrow*
+ts (2.google.protobuf.TimestampRts
+block (Rblock
+idx (Ridx
+tx (Rtx
+
+liquidator (R
+liquidator
+borrower (Rborrower 
+repayAmount (RrepayAmount*
+cTokenCollateral (RcTokenCollateral 
+seizeTokens	 (RseizeTokensB#Z!blep.ai/data/protoregistry/prtestbproto3


### PR DESCRIPTION
COR-126 (issue)
1. Stop connectors from using nfs server, migrate all proto descriptor files from nfs server to the database
2. Producer connectors must generate descriptor file now (instead of sink connectors) when registering proto.