### PR TITLE
[COR-178] Fix MeterProvider bug

### DIFF
--- a/monitor/otel.go
+++ b/monitor/otel.go
@@ -8,6 +8,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/metric/global"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
@@ -66,6 +67,7 @@ func InitMeterProvider(ctx context.Context, host string) (*metric.MeterProvider,
 	}
 
 	meterProvider := metric.NewMeterProvider(metric.WithReader(metric.NewPeriodicReader(exp)))
+	global.SetMeterProvider(meterProvider)
 
 	return meterProvider, nil
 }


### PR DESCRIPTION
Set global meter provider in `InitMeterProvider` in monitor package. This is to fix a bug in streamserver