### PR TITLE
[COR-177] Fix unresolved latency and metrics issues

### DIFF
--- a/chain/ethereum/go.mod
+++ b/chain/ethereum/go.mod
@@ -5,8 +5,9 @@ go 1.18
 require (
 	github.com/ethereum/go-ethereum v1.10.15
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d
-	github.com/nakji-network/connector v0.0.1-beta.1.0.20221030024423-a801338780fd
+	github.com/nakji-network/connector v0.0.1-beta.1.0.20221110211311-416552a01359
 	github.com/rs/zerolog v1.28.0
+	go.opentelemetry.io/otel v1.11.1
 	go.opentelemetry.io/otel/trace v1.11.1
 )
 
@@ -50,7 +51,6 @@ require (
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.5 // indirect
 	github.com/tklauser/numcpus v0.2.2 // indirect
-	go.opentelemetry.io/otel v1.11.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/internal/retry v1.11.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric v0.33.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v0.33.0 // indirect

--- a/chain/ethereum/go.sum
+++ b/chain/ethereum/go.sum
@@ -414,8 +414,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nakji-network/connector v0.0.1-beta.1.0.20221030024423-a801338780fd h1:O5YWgoWOGWtTLMXEHEC7Q+q1MXLMT+asXm5EJ83sMuc=
-github.com/nakji-network/connector v0.0.1-beta.1.0.20221030024423-a801338780fd/go.mod h1:/LWxlRLVonfLjIHHz8grGal2vpmuNdwW0hzM43Rn/z4=
+github.com/nakji-network/connector v0.0.1-beta.1.0.20221110211311-416552a01359 h1:zCl0FeaXRtVXQwQFl+LHs5uxDDzRgl+pPuhf3a25mHY=
+github.com/nakji-network/connector v0.0.1-beta.1.0.20221110211311-416552a01359/go.mod h1:/LWxlRLVonfLjIHHz8grGal2vpmuNdwW0hzM43Rn/z4=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nrwiersma/avro-benchmarks v0.0.0-20210913175520-21aec48c8f76/go.mod h1:iKyFMidsk/sVYONJRE372sJuX/QTRPacU7imPqqsu7g=

--- a/chain/ethereum/subscription.go
+++ b/chain/ethereum/subscription.go
@@ -264,7 +264,7 @@ func (s *Subscription) subscribeLogs(ctx context.Context) {
 			// Time that logs are received. This is the end time for RPC latency
 			rcvTime := time.Now()
 			// Add rcvTime to baggage as connector latency observation
-			spanCtx, bag := monitor.NewLatencyBaggage(context.TODO(), monitor.LatencyConnectorKey, rcvTime)
+			spanCtx, bag := monitor.NewLatencyBaggage(ctx, monitor.LatencyConnectorKey, rcvTime)
 
 			// Connector latency span begin
 			tr := monitor.CreateTracer(monitor.DefaultTracerName)

--- a/chain/ethereum/subscription.go
+++ b/chain/ethereum/subscription.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ethereum/go-ethereum/ethclient"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -63,7 +64,8 @@ type Subscription struct {
 
 type Log struct {
 	types.Log
-	Context context.Context
+	Span    trace.Span
+	Baggage baggage.Baggage
 }
 
 // NewSubscription	connects to given endpoints and subscribes to blockchain.
@@ -262,7 +264,7 @@ func (s *Subscription) subscribeLogs(ctx context.Context) {
 			// Time that logs are received. This is the end time for RPC latency
 			rcvTime := time.Now()
 			// Add rcvTime to baggage as connector latency observation
-			spanCtx := monitor.NewLatencyBaggage(context.TODO(), monitor.LatencyConnectorKey, rcvTime)
+			spanCtx, bag := monitor.NewLatencyBaggage(context.TODO(), monitor.LatencyConnectorKey, rcvTime)
 
 			// Connector latency span begin
 			tr := monitor.CreateTracer(monitor.DefaultTracerName)
@@ -298,10 +300,10 @@ func (s *Subscription) subscribeLogs(ctx context.Context) {
 				)
 				rpcSpan.End(trace.WithTimestamp(rcvTime))
 				// Add block time to baggage as rpc latency observation
-				spanCtx = monitor.NewLatencyBaggage(spanCtx, monitor.LatencyRpcKey, spanStart)
+				spanCtx, bag = monitor.NewLatencyBaggage(spanCtx, monitor.LatencyRpcKey, spanStart)
 			}
 
-			s.outLogs <- Log{vLog, spanCtx}
+			s.outLogs <- Log{vLog, span, bag}
 		}
 	}
 }

--- a/chain/ethereum/subscription_test.go
+++ b/chain/ethereum/subscription_test.go
@@ -43,7 +43,7 @@ func TestClose(t *testing.T) {
 		headers: make(chan *types.Header),
 		client:  &ethclient.Client{},
 		inLogs:  make(chan types.Log),
-		outLogs: make(chan types.Log),
+		outLogs: make(chan Log),
 		inErr:   make(chan error),
 		outErr:  make(chan error),
 	}

--- a/connector.go
+++ b/connector.go
@@ -11,13 +11,13 @@ import (
 	"github.com/nakji-network/connector/kafkautils"
 	"github.com/nakji-network/connector/monitor"
 	"github.com/nakji-network/connector/protoregistry"
-	"go.opentelemetry.io/otel/baggage"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"github.com/heptiolabs/healthcheck"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/kafkautils/message.go
+++ b/kafkautils/message.go
@@ -1,9 +1,9 @@
 package kafkautils
 
 import (
-	"context"
-
 	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"go.opentelemetry.io/otel/baggage"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -16,7 +16,8 @@ type Message struct {
 	Key      Key
 	MsgType  MsgType
 	ProtoMsg proto.Message
-	Context  context.Context
+	Span     trace.Span
+	Baggage  baggage.Baggage
 }
 
 type MsgType string

--- a/monitor/baggage.go
+++ b/monitor/baggage.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewLatencyBaggage takes in baggage member key and value, creates baggage, adds to context, and returns context.
-func NewLatencyBaggage(ctx context.Context, memberKey string, memberVal time.Time) context.Context {
+func NewLatencyBaggage(ctx context.Context, memberKey string, memberVal time.Time) (context.Context, baggage.Baggage) {
 	// Baggage member values must be strings
 	latencyStr := strconv.Itoa(int(memberVal.UnixMicro()))
 
@@ -28,5 +28,5 @@ func NewLatencyBaggage(ctx context.Context, memberKey string, memberVal time.Tim
 
 	ctx = baggage.ContextWithBaggage(ctx, bag)
 
-	return ctx
+	return ctx, bag
 }


### PR DESCRIPTION
Fixes unresolved issues from adding tracing for `0.2.0` release including:

* Removes context from `Log` in Ethereum subscription and `kafkautils.Message` and uses baggage and span instead
* Return baggage in `monitor.NewLatencyBaggage` for cases where baggage is not passed using context.
* Update usage of `Log` and `kafkautils.Message` to reflect these changes
* Move `ctx` to first parameter  in several functions in `producer.go` to match [convention](https://github.com/golang/go/wiki/CodeReviewComments#contexts). Passing context between functions is retained rather than passing `nil` for empty span or baggage because it's cleaner and functions that extract baggage or spans from context automatically handle the case where there is no span or baggage. No need to check for `nil` values.
* Fix Ethereum subscription tests to use local `Log` with baggage and span rather than `types.Log` from geth