### PR TITLE
[COR-177] Latency Fixes

### DIFF
--- a/monitor/metric.go
+++ b/monitor/metric.go
@@ -9,11 +9,16 @@ import (
 	"go.opentelemetry.io/otel/baggage"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/instrument"
+	"go.opentelemetry.io/otel/metric/unit"
 )
 
-type Histogram struct {
-	name        string
-	description string
+type latencyHistogram struct {
+	meter                metric.Meter
+	histogramName        string
+	histogramDescription string
+	connectorName        string
+	env                  string
+	value                int64
 }
 
 const (
@@ -22,102 +27,129 @@ const (
 	LatencyConnectorKey           = "latencyconn"
 	LatencyKafkaProduceKey        = "latencykafkaprod"
 	LatencyStreamserverConsumeKey = "latencyssconsume"
-
-	// Metric keys
-	rpcLatency    = 0
-	connLatency   = 1
-	coreLatency   = 2
-	systemLatency = 3
-	e2eLatency    = 4
-)
-
-var (
-	latencyObservations = map[string]int64{
-		LatencyRpcKey:                 0,
-		LatencyConnectorKey:           0,
-		LatencyKafkaProduceKey:        0,
-		LatencyStreamserverConsumeKey: 0,
-	}
-	latencyMetrics = map[int]int64{
-		rpcLatency:    0,
-		connLatency:   0,
-		coreLatency:   0,
-		systemLatency: 0,
-		e2eLatency:    0,
-	}
-	histograms = map[int]Histogram{
-		rpcLatency:    {name: "latency.rpc.histogram", description: "Latency from block time to connector reception"},
-		connLatency:   {name: "latency.connector.histogram", description: "Latency from connector reception to kafka produce"},
-		coreLatency:   {name: "latency.core.histogram", description: "Latency from kafka to streamserver"},
-		systemLatency: {name: "latency.system.histogram", description: "Latency from connector to streamserver"},
-		e2eLatency:    {name: "latency.e2e.histogram", description: "Latency from block time to streamserver"},
-	}
 )
 
 // ExportLatencyMetrics exports latency metrics from baggage in ctx
-func ExportLatencyMetrics(ctx context.Context, meter metric.Meter, connName string, env string) {
-	bag := baggage.FromContext(ctx)
 
-	// Extract latency observations from baggage
-	for key := range latencyObservations {
-		latencyObservations[key] = getBaggageLatency(bag, key)
+func RecordRpcLatency(ctx context.Context, meter metric.Meter, connName string, env string) {
+	rpcLatency := latencyHistogram{
+		meter:                meter,
+		histogramName:        "latency.rpc.histogram",
+		histogramDescription: "Latency from block time to connector reception",
+		connectorName:        connName,
+		env:                  env,
+		value:                0,
 	}
 
-	// Get observations
-	rpcObservation := latencyObservations[LatencyRpcKey]
-	connObservation := latencyObservations[LatencyConnectorKey]
-	kafkaProduceObservation := latencyObservations[LatencyKafkaProduceKey]
-	ssConsumeObservation := latencyObservations[LatencyStreamserverConsumeKey]
+	rpcObservation := getBaggageLatency(ctx, LatencyRpcKey)
+	connObservation := getBaggageLatency(ctx, LatencyConnectorKey)
 
-	// Derive latency metrics from observations
 	if rpcObservation > 0 && connObservation > 0 {
-		latencyMetrics[rpcLatency] = connObservation - rpcObservation
-	} else {
-		latencyMetrics[rpcLatency] = 0
+		rpcLatency.value = connObservation - rpcObservation
 	}
+
+	recordLatencyHistogram(ctx, rpcLatency)
+}
+
+func RecordConnectorLatency(ctx context.Context, meter metric.Meter, connName string, env string) {
+	connectorLatency := latencyHistogram{
+		meter:                meter,
+		histogramName:        "latency.connector.histogram",
+		histogramDescription: "Latency from connector reception to kafka produce",
+		connectorName:        connName,
+		env:                  env,
+		value:                0,
+	}
+
+	connObservation := getBaggageLatency(ctx, LatencyConnectorKey)
+	kafkaProduceObservation := getBaggageLatency(ctx, LatencyKafkaProduceKey)
 
 	if kafkaProduceObservation > 0 && connObservation > 0 {
-		latencyMetrics[connLatency] = kafkaProduceObservation - connObservation
-	} else {
-		latencyMetrics[connLatency] = 0
+		connectorLatency.value = kafkaProduceObservation - connObservation
 	}
+
+	recordLatencyHistogram(ctx, connectorLatency)
+}
+
+func RecordCoreLatency(ctx context.Context, meter metric.Meter, connName string, env string) {
+	coreLatency := latencyHistogram{
+		meter:                meter,
+		histogramName:        "latency.core.histogram",
+		histogramDescription: "Latency from kafka to streamserver",
+		connectorName:        connName,
+		env:                  env,
+		value:                0,
+	}
+
+	kafkaProduceObservation := getBaggageLatency(ctx, LatencyKafkaProduceKey)
+	ssConsumeObservation := getBaggageLatency(ctx, LatencyStreamserverConsumeKey)
 
 	if ssConsumeObservation > 0 && kafkaProduceObservation > 0 {
-		latencyMetrics[coreLatency] = ssConsumeObservation - kafkaProduceObservation
-	} else {
-		latencyMetrics[coreLatency] = 0
+		coreLatency.value = ssConsumeObservation - kafkaProduceObservation
 	}
+
+	recordLatencyHistogram(ctx, coreLatency)
+}
+
+func RecordSystemLatency(ctx context.Context, meter metric.Meter, connName string, env string) {
+	systemLatency := latencyHistogram{
+		meter:                meter,
+		histogramName:        "latency.system.histogram",
+		histogramDescription: "Latency from connector to streamserver",
+		connectorName:        connName,
+		env:                  env,
+		value:                0,
+	}
+
+	connObservation := getBaggageLatency(ctx, LatencyConnectorKey)
+	ssConsumeObservation := getBaggageLatency(ctx, LatencyStreamserverConsumeKey)
 
 	if ssConsumeObservation > 0 && connObservation > 0 {
-		latencyMetrics[systemLatency] = ssConsumeObservation - connObservation
-	} else {
-		latencyMetrics[systemLatency] = 0
+		systemLatency.value = ssConsumeObservation - connObservation
 	}
+
+	recordLatencyHistogram(ctx, systemLatency)
+}
+
+func RecordEndLatency(ctx context.Context, meter metric.Meter, connName string, env string) {
+	e2eLatency := latencyHistogram{
+		meter:                meter,
+		histogramName:        "latency.e2e.histogram",
+		histogramDescription: "Latency from block time to streamserver",
+		connectorName:        connName,
+		env:                  env,
+		value:                0,
+	}
+
+	rpcObservation := getBaggageLatency(ctx, LatencyRpcKey)
+	ssConsumeObservation := getBaggageLatency(ctx, LatencyStreamserverConsumeKey)
 
 	if ssConsumeObservation > 0 && rpcObservation > 0 {
-		latencyMetrics[e2eLatency] = ssConsumeObservation - rpcObservation
-	} else {
-		latencyMetrics[e2eLatency] = 0
+		e2eLatency.value = ssConsumeObservation - rpcObservation
 	}
 
-	// Record histograms
-	for key, hist := range histograms {
-		latency := latencyMetrics[key]
-		if latency > 0 {
-			histogramMetric, err := meter.SyncInt64().Histogram(
-				hist.name,
-				instrument.WithUnit("microseconds"),
-				instrument.WithDescription(hist.description),
-			)
-			if err != nil {
-				log.Error().Err(err).Str("histogram", hist.name).Msg("Unable to create histogram")
-			}
-			histogramMetric.Record(ctx, latency, attribute.String("Connector", connName), attribute.String("Env", env))
+	recordLatencyHistogram(ctx, e2eLatency)
+}
+
+func recordLatencyHistogram(ctx context.Context, obs latencyHistogram) {
+	if obs.value > 0 {
+		// Convert latency from microseconds to float milliseconds
+		latency := float64(obs.value) / 1000
+		histogram, err := obs.meter.SyncFloat64().Histogram(
+			obs.histogramName,
+			instrument.WithUnit(unit.Milliseconds),
+			instrument.WithDescription(obs.histogramDescription),
+		)
+		if err != nil {
+			log.Error().Err(err).Str("connector", obs.connectorName).Str("histogram", obs.histogramName).Msg("Unable to create histogram")
 		}
+		histogram.Record(ctx, latency, attribute.String("Connector", obs.connectorName), attribute.String("Env", obs.env))
 	}
 }
 
-func getBaggageLatency(bag baggage.Baggage, key string) int64 {
+func getBaggageLatency(ctx context.Context, key string) int64 {
+	bag := baggage.FromContext(ctx)
+
 	mem := bag.Member(key)
 	ts, err := strconv.Atoi(mem.Value())
 	// Baggage key does not exist

--- a/monitor/metric_test.go
+++ b/monitor/metric_test.go
@@ -1,6 +1,7 @@
 package monitor
 
 import (
+	"context"
 	"testing"
 
 	"go.opentelemetry.io/otel/baggage"
@@ -8,7 +9,7 @@ import (
 
 func TestGetBaggageLatency(t *testing.T) {
 	type args struct {
-		bag baggage.Baggage
+		ctx context.Context
 		key string
 	}
 	tests := []struct {
@@ -51,15 +52,16 @@ func TestGetBaggageLatency(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getBaggageLatency(tt.args.bag, tt.args.key); got != tt.want {
+			if got := getBaggageLatency(tt.args.ctx, tt.args.key); got != tt.want {
 				t.Errorf("Get() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-func createBaggage(key string, value string) baggage.Baggage {
+func createBaggage(key string, value string) context.Context {
 	member, _ := baggage.NewMember(key, value)
 	bag, _ := baggage.New(member)
-	return bag
+	ctx := baggage.ContextWithBaggage(context.TODO(), bag)
+	return ctx
 }


### PR DESCRIPTION
Fixes a couple of issues from initial latency PR. 

### Latency Units

Latencies were exported in microseconds, so the values fell outside of all buckets for histogram. Latencies are still recorded in microseconds, but exported in float64 milliseconds. 

Example of current data from prod:

```
# HELP latency_connector_histogram Latency from connector reception to kafka produce
# TYPE latency_connector_histogram histogram
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="0"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="5"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="10"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="25"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="50"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="75"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="100"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="250"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="500"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="750"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="1000"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="2500"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="5000"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="7500"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="10000"} 0
latency_connector_histogram_bucket{Connector="sushiswap",Env="prod",job="streamserver",le="+Inf"} 54470
latency_connector_histogram_sum{Connector="sushiswap",Env="prod",job="streamserver"} 4.2127170146e+10
```

Example from local testing with updated units:

```
# HELP latency_connector_histogram Latency from connector reception to kafka produce
# TYPE latency_connector_histogram histogram
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="0"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="5"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="10"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="25"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="50"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="75"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="100"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="250"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="500"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="750"} 0
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="1000"} 18
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="2500"} 31
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="5000"} 41
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="7500"} 42
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="10000"} 42
latency_connector_histogram_bucket{Connector="streamserver",Env="staging",job="streamserver",le="+Inf"} 42
latency_connector_histogram_sum{Connector="streamserver",Env="staging",job="streamserver"} 76029.403
latency_connector_histogram_count{Connector="streamserver",Env="staging",job="streamserver"} 42
```

After this update, a dash to show the distribution of latency values will be possible. Currently, we can only see a mean and that all values are less than infinity.

### `metric.go` Updates

`ExportLatencyMetrics` was refactored to be more readable. It performs the same function, but in a way where someone that isn't me can tell what is going on. The initial version was a confusing mess of maps (sorry). The unit tests were updated to match the changes as well.