### PR TITLE
[INT-385] Deprecate old connector functions

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -36,7 +36,7 @@ type Connector struct {
 	Config *viper.Viper
 	Health healthcheck.Handler
 
-	//	DEPRECATED, please use ProduceWithTransaction instead
+	//	DEPRECATED, this property will be removed in a future release. Please use ProduceWithTransaction instead.
 	//	EventSink can be used to push incoming on-chain events to Kafka.
 	// 	All kafka Produce logic will be handled under the hood.
 	EventSink chan<- *kafkautils.Message
@@ -186,14 +186,16 @@ func (c *Connector) SubscribeExample() error {
 	return nil
 }
 
-// ProduceMessage sends protobuf to message queue with a Topic and Key.
+//	DEPRECATED, this function will be removed in a future release. Please use ProduceWithTransaction instead.
+//	ProduceMessage sends protobuf to message queue with a Topic and Key.
 func (c *Connector) ProduceMessage(namespace, subject string, msgType kafkautils.MsgType, msg proto.Message) error {
 	topic := c.generateTopicFromProto(msgType, msg)
 	key := kafkautils.NewKey(namespace, subject)
 	return c.ProduceMsg(context.TODO(), topic.String(), msg, key.Bytes(), nil)
 }
 
-// ProduceAndCommitMessage sends protobuf to message queue with a Topic and Key.
+//	DEPRECATED, this function will be removed in a future release. Please use ProduceWithTransaction instead.
+//	ProduceAndCommitMessage sends protobuf to message queue with a Topic and Key.
 func (c *Connector) ProduceAndCommitMessage(namespace, subject string, msgType kafkautils.MsgType, msg proto.Message) error {
 	if !c.producerStarted {
 		err := c.startProducer()
@@ -307,7 +309,7 @@ func (c *Connector) buildTopicTypes(msgType kafkautils.MsgType, protos ...proto.
 	return tt
 }
 
-//	DEPRECATED, please use ProduceWithTransaction instead
+//	DEPRECATED, this function will be removed in a future release. Please use ProduceWithTransaction instead.
 //	initProduceChannel uses the incoming messages from protobuf message channel and forwards them to Kafka.
 //	It wraps each message in a Kafka Transaction to ensure Exactly Once Semantics.
 //	NOTE: this wraps individual messages with transactions so it adds a lot of overhead to kafka and reduces the usefulness of transactions

--- a/kafkautils/producer.go
+++ b/kafkautils/producer.go
@@ -240,6 +240,7 @@ func (p *Producer) SendOffsetsToTransaction(position kafka.TopicPartitions, c *C
 	}
 }
 
+// DEPRECATED, this function will be removed in a future release. Please use ProduceWithTransaction in connector.go instead.
 // WriteAndCommit writes for transactional producers, committing transaction after each write
 func (p *Producer) WriteAndCommit(ctx context.Context, topic Topic, key []byte, value proto.Message) error {
 	err := p.ProduceMsg(ctx, topic.String(), value, key, nil)
@@ -275,6 +276,7 @@ retry:
 
 const txBatchSize = 50
 
+// DEPRECATED, this function will be removed in a future release. Please use ProduceWithTransaction in connector.go instead.
 // WriteAndCommitSink will wrap messages in a transaction. The transaction is committed
 // once there are 10 messages in the transaction or if the interval timer has been hit.
 func (p *Producer) WriteAndCommitSink(in <-chan *Message) {
@@ -345,6 +347,7 @@ func (p *Producer) WriteAndCommitSink(in <-chan *Message) {
 	}
 }
 
+// DEPRECATED, this function will be removed in a future release. Please use ProduceWithTransaction in connector.go instead.
 // MakeQueueTransactionSink creates a channel that receives Kafka Messages. All messages within the channel are then automatically
 // published to the specific topic in the `*kafkautils.Message`.
 func (p *Producer) MakeQueueTransactionSink() chan *Message {


### PR DESCRIPTION
Deprecate older message producing functions in `connector` and `kafkautils.producer`. 
