### PR TITLE
Increment interval start

### DIFF
--- a/chain/ethereum/ethereum.go
+++ b/chain/ethereum/ethereum.go
@@ -231,7 +231,7 @@ func BatchedFilterLogs(ctx context.Context, client ETHClient, addresses []common
 			// this will also process the good blocks in a binary search fashion.
 			mid := (query.FromBlock.Uint64() + query.ToBlock.Uint64()) / 2
 			BatchedFilterLogs(ctx, client, addresses, fromBlock, mid, logChan, backoff<<1)
-			BatchedFilterLogs(ctx, client, addresses, mid, toBlock, logChan, backoff<<1)
+			BatchedFilterLogs(ctx, client, addresses, mid+1, toBlock, logChan, backoff<<1)
 			return
 		}
 	}


### PR DESCRIPTION
Failed backfill intervals are split into two to process in two steps. However, this division can go all the way down to 1 block. 
In that case, the routine will just loop. This PR fixes that.