### PR TITLE
[INT-374][INT-440] Add Filter Query to Backfill

### DIFF
--- a/chain/ethereum/ethereum.go
+++ b/chain/ethereum/ethereum.go
@@ -490,18 +490,14 @@ func BackfillEventsWithQueryParams(ctx context.Context, client *ethclient.Client
 		return ch, err
 	}
 
-	var f uint64
+	f := fromBlock
 	if fromBlock == 0 && numBlocks > 0 {
 		f = latestBlockNumber - numBlocks
-	} else {
-		f = fromBlock
 	}
 
-	var t uint64
+	t := latestBlockNumber
 	if (fromBlock > 0 && numBlocks > 0) && (fromBlock+numBlocks < latestBlockNumber) {
 		t = fromBlock + numBlocks
-	} else {
-		t = latestBlockNumber
 	}
 
 	q := ethereum.FilterQuery{


### PR DESCRIPTION
Some backfills include filtering by event `Topic`. Previously, we only filtered by `Address` and/or block height. 
This PR adds the functionality to filter by topic. 